### PR TITLE
Atomixrex - modify notebook to use only a single core

### DIFF
--- a/day_2/atomicrex/WorkshopPotentialEAM.ipynb
+++ b/day_2/atomicrex/WorkshopPotentialEAM.ipynb
@@ -495,7 +495,6 @@
     "job.input.atom_types.Cu = None\n",
     "##\n",
     "job.input.fit_algorithm = job.factories.algorithms.ar_lbfgs(max_iter=500000)\n",
-    "job.server.cores = 16\n",
     "job.run()\n",
     "job.output"
    ]

--- a/day_2/atomicrex/WorkshopPotentialEAM.ipynb
+++ b/day_2/atomicrex/WorkshopPotentialEAM.ipynb
@@ -567,7 +567,6 @@
     }
    ],
    "source": [
-    "j.server.cores = 16\n",
     "t1 = time.time()\n",
     "j.run()\n",
     "t2 = time.time()"
@@ -647,7 +646,6 @@
     "j2.potential = job.potential.copy()\n",
     "j2.input = j.input.copy()\n",
     "j2.structures = j.structures\n",
-    "j2.server.cores = 14\n",
     "j2.run()"
    ]
   },


### PR DESCRIPTION
@Leimeroth On the docker infrastructure for the workshop we only have one or two cores available per participant.  